### PR TITLE
Optimize GraphQL Site Query

### DIFF
--- a/src/app/graphql/queries.ts
+++ b/src/app/graphql/queries.ts
@@ -1,6 +1,15 @@
 import { gql } from '@apollo/client';
 import * as Fragments from './fragments';
 
+export const GET_SITE_ID = gql`
+  query GetSiteIdByClientId($ClientId: String) {
+    sites(filters: { ClientId: { eq: $ClientId } }, pagination: { limit: 1 }) {
+      data {
+        id
+      }
+    }
+  }
+`;
 export const GET_SITE = gql`
   # Fragments
   ${Fragments.HERO}
@@ -14,8 +23,8 @@ export const GET_SITE = gql`
   ${Fragments.IMAGE_SCROLL}
   ${Fragments.FEATURE_SECTION}
 
-  query Site($ClientId: String) {
-    sites(filters: { ClientId: { eq: $ClientId } }) {
+  query Site($id: ID!) {
+    site(id: $id) {
       data {
         attributes {
           ClientId

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -130,23 +130,23 @@ const Home = () => {
         <Box>
           <Stack gap={0}>
             <Hero hero={hero} />
-            {featureSection?.features?.length > 0 && (
+            {featureSection && (
               <FeatureSection featureSection={featureSection} />
             )}
             {imageScroll && <ImageScroll imageScroll={imageScroll} />}
             {sections.map((i) => (
               <Section key={`section-${i.sortOrder}`} section={i} />
             ))}
-            {carousel?.images?.length > 0 && <Carousel carousel={carousel} />}
-            {projectSection?.articles?.length > 0 && (
+            {carousel && <Carousel carousel={carousel} />}
+            {projectSection && (
               <ProjectSection projectSection={projectSection} />
             )}
-            {contact.fields && (
+            {contact && (
               <ContactForm hero={hero} sections={sections} contact={contact} />
             )}
           </Stack>
         </Box>
-        <Footer buttonStyle={primaryButtonStyle} footer={footer} />
+        {footer && <Footer buttonStyle={primaryButtonStyle} footer={footer} />}
       </Box>
     </main>
   );


### PR DESCRIPTION
Split query into two requests, one to get the site entry id in strapi db, the other to fetch using findOne with that id.  Ensures we don't waste resources grabbing multiple sites and filtering.